### PR TITLE
fix: return correct cleaned file path

### DIFF
--- a/backend/app/services/data_alchemy.py
+++ b/backend/app/services/data_alchemy.py
@@ -99,12 +99,10 @@ def run(file_path: str, params: Dict[str, Any]) -> Dict[str, Any]:
     out_path = Path(file_path).with_name(Path(file_path).stem + "__cleaned.parquet")
     try:
         df.to_parquet(out_path)
-        saved_path = out_path.name
     except Exception:
-        # Fallback to CSV
-        out_csv = Path(file_path).with_name(Path(file_path).stem + "__cleaned.csv")
-        df.to_csv(out_csv, index=False)
-        saved_path = out_csv.name
+        # Fallback to CSV if parquet isn't supported
+        out_path = Path(file_path).with_name(Path(file_path).stem + "__cleaned.csv")
+        df.to_csv(out_path, index=False)
     return {
         "summary": "Data transformation pipeline executed",
         "file": file_path,


### PR DESCRIPTION
## Summary
- ensure Data Alchemy service returns the actual path of the cleaned file after saving

## Testing
- `pytest -q`
- `npm run lint` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c99110cc8321875910d70ad56176