### PR TITLE
Ensure http adds default JSON header

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -7,9 +7,10 @@ export const API_BASE: string =
   DEFAULT_BASE;
 
 async function http<T>(path: string, init?: RequestInit): Promise<T> {
+  const headers = { "Content-Type": "application/json", ...(init?.headers || {}) };
   const res = await fetch(`${API_BASE}${path}`, {
-    headers: { "Content-Type": "application/json", ...(init?.headers || {}) },
     ...init,
+    headers,
   });
   if (!res.ok) {
     const text = await res.text();


### PR DESCRIPTION
## Summary
- Merge default `Content-Type: application/json` with supplied headers in `http`
- Spread `init` options before merged headers so defaults persist

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 32 problems (24 errors, 8 warnings))*
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a1cb02b850832182788a72a5c2e8c3