### PR TITLE
docs: document upload delimiter and sheet name

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -62,7 +62,7 @@ backend/
 ## API Overview (FastAPI)
 
 - Health: GET /health
-- Upload: POST /api/upload (multipart/form-data key: "file")
+- Upload: POST /api/upload (multipart/form-data key: "file"; optional "delimiter" and "sheet_name" for CSV and Excel files)
 - Tasks:
   - POST /api/tasks/data-alchemy
   - POST /api/tasks/neural-canvas
@@ -75,8 +75,12 @@ backend/
 ```
 curl -X POST http://localhost:8000/api/upload \
   -H "Content-Type: multipart/form-data" \
-  -F "file=@/path/to/your.csv"
+  -F "file=@/path/to/your.csv" \
+  -F "delimiter=," \
+  -F "sheet_name=Sheet1"
 ```
+
+Use the `delimiter` field for CSV files and `sheet_name` to target a sheet in Excel uploads.
 
 Response
 ```


### PR DESCRIPTION
## Summary
- document optional `delimiter` and `sheet_name` fields for `/api/upload`
- show example curl using these options

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: found 24 errors, 8 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a1cbe6505083219c4f5d8ed5fadac7